### PR TITLE
[FIX][17.0] helpdesk_mgmt_stage_server_action: Fix context when calling server action

### DIFF
--- a/helpdesk_mgmt_stage_server_action/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_stage_server_action/models/helpdesk_ticket.py
@@ -17,6 +17,7 @@ class HelpdeskTicket(models.Model):
             context = {
                 "active_model": self._name,
                 "active_id": record.id,
+                "active_ids": records.ids,
             }
             action.with_context(**context).run()
         return records
@@ -33,6 +34,7 @@ class HelpdeskTicket(models.Model):
             if action:
                 context = {
                     "active_model": self._name,
+                    "active_id": records.id,
                     "active_ids": records.ids,
                 }
                 action.with_context(**context).run()


### PR DESCRIPTION
Because depending of where you provides into the UI, the `active_id` or `active_ids` can be already set.